### PR TITLE
Use the ARM for check_std

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     env:
-      RUSTFLAGS: -Dwarnings
+      RUSTFLAGS: -Dwarnings --cfg ci
     strategy:
       matrix:
         rust:
@@ -75,16 +75,15 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
             command: check
-            args: --all-features --examples --workspace --benches
+            args: --all-features --examples --all --benches
         if: matrix.rust == 'nightly'
 
       - name: Test
         uses: actions-rs/cargo@v1
         with:
             command: test
-            args: "--workspace \
-                   --all-features \
-                   --exclude ark-poly-benches"
+            args: "--all \
+                   --all-features"
 
   check_no_std:
     name: Check no_std
@@ -92,14 +91,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
-      - name: Install Rust (${{ matrix.rust }})
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          target: thumbv6m-none-eabi
-          override: true
-
+        
       - name: Install Rust ARM64 (${{ matrix.rust }})
         uses: actions-rs/toolchain@v1
         with:
@@ -115,14 +107,7 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: check
-        uses: actions-rs/cargo@v1
-        with:
-            command: check
-            args: --examples --workspace --exclude ark-poly-benches --target thumbv6m-none-eabi
-
-      - name: build
-        uses: actions-rs/cargo@v1
-        with:
-            command: build
-            args: --workspace --exclude ark-poly-benches --target thumbv6m-none-eabi
+      - name: Check
+        run: |
+          cargo build --no-default-features --target aarch64-unknown-none
+          cargo check --examples --no-default-features --target aarch64-unknown-none


### PR DESCRIPTION
When adding the CI for PCD and IVLS, I revisit this document.

I made some changes based on the CI.yml of `nonnative` but I am not sure if they are appropriate for the template. 

Thoughts?